### PR TITLE
Pass raw string instead of decoded string

### DIFF
--- a/t/01.translate_from_ja.t
+++ b/t/01.translate_from_ja.t
@@ -1,7 +1,6 @@
 #!perl
 
 use strict;
-use utf8;
 use Encode;
 
 use Acme::AjiFry;
@@ -12,21 +11,21 @@ my $got;
 my $aji_fry = Acme::AjiFry->new();
 
 $got = Encode::decode_utf8($aji_fry->to_AjiFry("おさしみ"));
-is($got, "食えアジフライお刺身食え食えお刺身ドボドボ岡星ドボドボ", "From Ja: 1");
+is($got, Encode::decode_utf8("食えアジフライお刺身食え食えお刺身ドボドボ岡星ドボドボ"), "From Ja: 1");
 
 $got = Encode::decode_utf8($aji_fry->to_AjiFry("あきらめたらそこでしあいしゅうりょうだよ"));
-is($got, "食え食え食えフライドボドボああ食え食え岡星むむ･･･アジ食え食えああ食え食えお刺身アジフライフライアジフライアジむむ･･･陶人お刺身ドボドボ食え食え食え食えドボドボお刺身ドボドボ中川ゴク･･･お刺身食えお刺身ああドボドボ中川ゴク･･･アジフライ食えお刺身アジ食え食え陶人ゴク･･･アジフライ", "From Ja: 2");
+is($got, Encode::decode_utf8("食え食え食えフライドボドボああ食え食え岡星むむ･･･アジ食え食えああ食え食えお刺身アジフライフライアジフライアジむむ･･･陶人お刺身ドボドボ食え食え食え食えドボドボお刺身ドボドボ中川ゴク･･･お刺身食えお刺身ああドボドボ中川ゴク･･･アジフライ食えお刺身アジ食え食え陶人ゴク･･･アジフライ"), "From Ja: 2");
 
 $got = Encode::decode_utf8($aji_fry->to_AjiFry("ぱりーぐ"));
-is($got, "山岡食え食え社主ああドボドボーフライお刺身陶人", "From Ja: 3");
+is($got, Encode::decode_utf8("山岡食え食え社主ああドボドボーフライお刺身陶人"), "From Ja: 3");
 
 $got = Encode::decode_utf8($aji_fry->to_AjiFry("んじゃめな"));
-is($got, "京極お刺身ドボドボ陶人中川ゴク･･･食え食え岡星むむ･･･ドボ食え食え", "From Ja: 4");
+is($got, Encode::decode_utf8("京極お刺身ドボドボ陶人中川ゴク･･･食え食え岡星むむ･･･ドボ食え食え"), "From Ja: 4");
 
 $got = Encode::decode_utf8($aji_fry->to_AjiFry(""));
-is($got, '', "From Ja: 5");
+is($got, Encode::decode_utf8(''), "From Ja: 5");
 
 $got = Encode::decode_utf8($aji_fry->translate_to_ajifry("おさしみ"));
-is($got, "食えアジフライお刺身食え食えお刺身ドボドボ岡星ドボドボ", "Other way");
+is($got, Encode::decode_utf8("食えアジフライお刺身食え食えお刺身ドボドボ岡星ドボドボ"), "Other way");
 
 done_testing();

--- a/t/02.translate_to_ja.t
+++ b/t/02.translate_to_ja.t
@@ -1,7 +1,6 @@
 #!perl
 
 use strict;
-use utf8;
 use Encode;
 
 use Acme::AjiFry;
@@ -12,21 +11,21 @@ my $got;
 my $aji_fry = Acme::AjiFry->new();
 
 $got = Encode::decode_utf8($aji_fry->to_Japanese("食えアジフライお刺身食え食えお刺身ドボドボ岡星ドボドボ"));
-is($got, "おさしみ", "To Ja: 1");
+is($got, Encode::decode_utf8("おさしみ"), "To Ja: 1");
 
 $got = Encode::decode_utf8($aji_fry->to_Japanese("山岡食え食え社主ああドボドボーフライお刺身陶人"));
-is($got, "ぱりーぐ", "To Ja: 2");
+is($got, Encode::decode_utf8("ぱりーぐ"), "To Ja: 2");
 
 $got = Encode::decode_utf8($aji_fry->to_Japanese("食え食え食えフライドボドボああ食え食え岡星むむ･･･アジ食え食えああ食え食えお刺身アジフライフライアジフライアジむむ･･･陶人お刺身ドボドボ食え食え食え食えドボドボお刺身ドボドボ中川ゴク･･･お刺身食えお刺身ああドボドボ中川ゴク･･･アジフライ食えお刺身アジ食え食え陶人ゴク･･･アジフライ"));
-is($got, "あきらめたらそこでしあいしゅうりょうだよ", "To Ja: 3");
+is($got, Encode::decode_utf8("あきらめたらそこでしあいしゅうりょうだよ"), "To Ja: 3");
 
 $got = Encode::decode_utf8($aji_fry->to_Japanese("京極お刺身ドボドボ陶人中川ゴク･･･食え食え岡星むむ･･･ドボ食え食え"));
-is($got, "んじゃめな", "To Ja: 4");
+is($got, Encode::decode_utf8("んじゃめな"), "To Ja: 4");
 
 $got = Encode::decode_utf8($aji_fry->to_Japanese(""));
-is($got, "", "To Ja: 5");
+is($got, Encode::decode_utf8(""), "To Ja: 5");
 
 $got = Encode::decode_utf8($aji_fry->translate_from_ajifry("食えアジフライお刺身食え食えお刺身ドボドボ岡星ドボドボ"));
-is($got, "おさしみ", "To Ja: 1");
+is($got, Encode::decode_utf8("おさしみ"), "To Ja: 1");
 
 done_testing();

--- a/t/03.translate_reciprocally_ja.t
+++ b/t/03.translate_reciprocally_ja.t
@@ -1,7 +1,6 @@
 #!perl
 
 use strict;
-use utf8;
 use Encode;
 
 use Acme::AjiFry;
@@ -12,15 +11,15 @@ my $got;
 my $aji_fry = Acme::AjiFry->new();
 
 $got = Encode::decode_utf8($aji_fry->to_Japanese($aji_fry->to_AjiFry("おさしみ")));
-is($got, "おさしみ", "Translate reciprocally Ja: 1");
+is($got, Encode::decode_utf8("おさしみ"), "Translate reciprocally Ja: 1");
 
 $got = Encode::decode_utf8($aji_fry->to_Japanese($aji_fry->to_AjiFry("ぱりーぐ")));
-is($got, "ぱりーぐ", "Translate reciprocally Ja: 2");
+is($got, Encode::decode_utf8("ぱりーぐ"), "Translate reciprocally Ja: 2");
 
 $got = Encode::decode_utf8($aji_fry->to_Japanese($aji_fry->to_AjiFry("あきらめたらそこでしあいしゅうりょうだよ")));
-is($got, "あきらめたらそこでしあいしゅうりょうだよ", "Translate reciprocally Ja: 3");
+is($got, Encode::decode_utf8("あきらめたらそこでしあいしゅうりょうだよ"), "Translate reciprocally Ja: 3");
 
 $got = Encode::decode_utf8($aji_fry->to_Japanese($aji_fry->to_AjiFry("んじゃめな")));
-is($got, "んじゃめな", "Translate reciprocally Ja: 4");
+is($got, Encode::decode_utf8("んじゃめな"), "Translate reciprocally Ja: 4");
 
 done_testing();

--- a/t/04.translate_from_en.t
+++ b/t/04.translate_from_en.t
@@ -1,7 +1,6 @@
 #!perl
 
 use strict;
-use utf8;
 use Encode;
 
 use Acme::AjiFry::EN;
@@ -12,21 +11,21 @@ my $got;
 my $aji_fry_en = Acme::AjiFry::EN->new();
 
 $got = Encode::decode_utf8($aji_fry_en->to_AjiFry("0123456789"));
-is($got, "京極お刺身京極むむ･･･京極アジフライ陶人食え食え陶人ドボドボ陶人お刺身陶人むむ･･･陶人アジフライ社主食え食え社主ドボドボ", "Translate from En: 1");
+is($got, Encode::decode_utf8("京極お刺身京極むむ･･･京極アジフライ陶人食え食え陶人ドボドボ陶人お刺身陶人むむ･･･陶人アジフライ社主食え食え社主ドボドボ"), "Translate from En: 1");
 
 $got = Encode::decode_utf8($aji_fry_en->to_AjiFry("abcdefghijklmnopqrstuvwxyz"));
-is($got, "食え食え食え食えドボドボ食えお刺身食えむむ･･･食えアジフライフライ食え食えフライドボドボフライお刺身フライむむ･･･フライアジフライお刺身食え食えお刺身ドボドボお刺身お刺身お刺身むむ･･･お刺身アジフライアジ食え食えアジドボドボアジお刺身アジむむ･･･アジアジフライドボ食え食えドボドボドボドボお刺身ドボむむ･･･ドボアジフライ山岡食え食え", "Translate from En: 2");
+is($got, Encode::decode_utf8("食え食え食え食えドボドボ食えお刺身食えむむ･･･食えアジフライフライ食え食えフライドボドボフライお刺身フライむむ･･･フライアジフライお刺身食え食えお刺身ドボドボお刺身お刺身お刺身むむ･･･お刺身アジフライアジ食え食えアジドボドボアジお刺身アジむむ･･･アジアジフライドボ食え食えドボドボドボドボお刺身ドボむむ･･･ドボアジフライ山岡食え食え"), "Translate from En: 2");
 
 $got = Encode::decode_utf8($aji_fry_en->to_AjiFry("ABCDEFGHIJKLMNOPQRSTUVWXYZ"));
-is($got, "山岡ドボドボ山岡お刺身山岡むむ･･･山岡アジフライ岡星食え食え岡星ドボドボ岡星お刺身岡星むむ･･･岡星アジフライゴク･･･食え食えゴク･･･ドボドボゴク･･･お刺身ゴク･･･むむ･･･ゴク･･･アジフライああ食え食えああドボドボああお刺身ああむむ･･･ああアジフライ雄山食え食え雄山ドボドボ雄山お刺身雄山むむ･･･雄山アジフライ京極食え食え京極ドボドボ", "Translate from En: 3");
+is($got, Encode::decode_utf8("山岡ドボドボ山岡お刺身山岡むむ･･･山岡アジフライ岡星食え食え岡星ドボドボ岡星お刺身岡星むむ･･･岡星アジフライゴク･･･食え食えゴク･･･ドボドボゴク･･･お刺身ゴク･･･むむ･･･ゴク･･･アジフライああ食え食えああドボドボああお刺身ああむむ･･･ああアジフライ雄山食え食え雄山ドボドボ雄山お刺身雄山むむ･･･雄山アジフライ京極食え食え京極ドボドボ"), "Translate from En: 3");
 
 $got = Encode::decode_utf8($aji_fry_en->to_AjiFry("012abcDEFgH!4~-+::Z"));
-is($got, "京極お刺身京極むむ･･･京極アジフライ食え食え食え食えドボドボ食えお刺身山岡アジフライ岡星食え食え岡星ドボドボフライドボドボ岡星むむ･･･!陶人ドボドボ~-+::京極ドボドボ", "Translate from En: 4");
+is($got, Encode::decode_utf8("京極お刺身京極むむ･･･京極アジフライ食え食え食え食えドボドボ食えお刺身山岡アジフライ岡星食え食え岡星ドボドボフライドボドボ岡星むむ･･･!陶人ドボドボ~-+::京極ドボドボ"), "Translate from En: 4");
 
 $got = Encode::decode_utf8($aji_fry_en->to_AjiFry(""));
-is($got, "", "Translate from En: 5");
+is($got, Encode::decode_utf8(""), "Translate from En: 5");
 
 $got = Encode::decode_utf8($aji_fry_en->translate_to_ajifry("0123456789"));
-is($got, "京極お刺身京極むむ･･･京極アジフライ陶人食え食え陶人ドボドボ陶人お刺身陶人むむ･･･陶人アジフライ社主食え食え社主ドボドボ", "other way");
+is($got, Encode::decode_utf8("京極お刺身京極むむ･･･京極アジフライ陶人食え食え陶人ドボドボ陶人お刺身陶人むむ･･･陶人アジフライ社主食え食え社主ドボドボ"), "other way");
 
 done_testing();

--- a/t/05.translate_to_en.t
+++ b/t/05.translate_to_en.t
@@ -1,7 +1,6 @@
 #!perl
 
 use strict;
-use utf8;
 use Encode;
 
 use Acme::AjiFry::EN;


### PR DESCRIPTION
And recent Encode::decoded_utf8 raises error if argument is already decoded.

``` perl
#!/usr/bin/env perl
use strict;
use warnings;

use Encode 2.7.2;
use utf8;

my $a = decode_utf8("あいうえお");
print encode_utf8($a), "\n";
```

This output is

```
% perl test.pl
Cannot decode string with wide characters at /home/syohei/.plenv/versions/5.20.2/lib/perl5/site_perl/5.20.2/x86_64-linux-thread-multi/Encode.pm line 241.
```
